### PR TITLE
Bug fixes

### DIFF
--- a/mod.config.json
+++ b/mod.config.json
@@ -1,7 +1,7 @@
 {
 	"name": "HideoutShoppingList",
 	"author": "JakeLoustone",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"license": "MIT",
 	"src": {
 		"src/hideoutShoppingList.js": "TamperModLoad"

--- a/src/hideoutShoppingList.js
+++ b/src/hideoutShoppingList.js
@@ -242,6 +242,9 @@ exports.mod = (mod_info) => {
 	}
 
 	let isOrphan = (items, item) => {
+		if(item.parentId == null){
+			return false;
+		}
 		for(const otherItem of items){
 			if(otherItem._id == item.parentId){
 				return false;

--- a/src/hideoutShoppingList.js
+++ b/src/hideoutShoppingList.js
@@ -178,7 +178,7 @@ exports.mod = (mod_info) => {
 			}
 		}
 	
-		// Warn that an orphan has been found is necessary
+		// Warn that an orphan has been found if necessary
 		if(foundOrphan){
 			console.log("[Mod] HideoutShoppingList: Found orphan item in inventory! Consider cleaning your character.json");
 		}


### PR DESCRIPTION
Consider the situation where the only item in stash is a stack of 50 roubles.

Prior to fix, if we had 2 areas in hideout that required roubles to upgrade, it would count the same stack of 50 roubles twice.

This is because in populateItemsRequiredInStash(), when we iterate over the roubles in the outer most loop, we then add up the stackCount of the roubles for every area we find. This is not what we want. In this function, we only want to add the stackCount of the item if it is in the requirements. After that, we just want to skip to the next item. This is what I added with foundTemplateInReqs.

I also fixed how it also considered orphan items. I don't know how those appear but sometimes we have items with a parentId that doesn't match the _id field of any item in inventory. We don't want to consider those in the count of what we have in stash.

Also, an item without a parentId should not be considered orphan. There always seem to be the exact same instances of those in everyone's character.json (at least the other one I downloaded from the discord).

Incremented mod version to 1.0.2 while I was at it.