### PR TITLE
Stash total build up fix

### DIFF
--- a/mod.config.json
+++ b/mod.config.json
@@ -1,7 +1,7 @@
 {
 	"name": "HideoutShoppingList",
 	"author": "JakeLoustone",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"license": "MIT",
 	"src": {
 		"src/hideoutShoppingList.js": "TamperModLoad"

--- a/src/hideoutShoppingList.js
+++ b/src/hideoutShoppingList.js
@@ -54,6 +54,9 @@ exports.mod = (mod_info) => {
 	}
 
 	let updateExistingShoppingListIndex = (pmcData) => {
+		
+		// Reset the index because the list may have been deleted
+		existingShoppinglistIndex = -1;
 
 		for (let i in pmcData.Notes.Notes) {
 			let currentNote = pmcData.Notes.Notes[i];
@@ -73,6 +76,10 @@ exports.mod = (mod_info) => {
 
 	let populateItemsRequiredAmount = (pmcData) => {
 
+		// Reset the required items map because the area may have been completed since the start of the session
+		// We don't want to keep the requirements in the list if it was
+		areaRequiredItemsMap = new Map();
+	
 		for (let areaPmcData of pmcData.Hideout.Areas) {
 
 			//If its at starting level just skip it, the player is probably not trying to work on upgrading it from 0 yet?
@@ -134,6 +141,9 @@ exports.mod = (mod_info) => {
 
 	let populateItemsRequiredInStash = (pmcData) => {
 
+		// Reset items in stash map because otherwise the totals build up every time we recount them after each raid
+		itemsInStashMap = new Map();
+	
 		for (const tmpItem of pmcData.Inventory.items) {
 			
 			// Ignore orphan items


### PR DESCRIPTION
It seems as if the variables at the scope of shopping list index and stash map don't get reinitialized after each raid. That means, for example, in the same server session, if we do 2 raids, the first raid would count the total of a certain item, and the second raid would add the same total to the first total that was already found previously. So the total of a certain item we had would build up every raid. I just made sure the variables that are necessary to be reset are being reset at the start of the functions.

Also incremented mod version.

I probably missed the problem because when testing my previous fixes I would restart the server which would recompile the scripts, and that is the only time when those vars would get initialized.